### PR TITLE
fix: add refreshIfNoCache to RepositoryMock

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
     - RxSwift (~> 5)
   - SwiftFormat/CLI (0.40.14)
   - SwiftLint (0.37.0)
-  - Teller (0.6.0):
+  - Teller (0.7.0):
     - RxSwift (~> 5.0)
 
 DEPENDENCIES:
@@ -55,7 +55,7 @@ SPEC CHECKSUMS:
   RxTest: 4349afe98f564e0a9bc19063368904622d17d49a
   SwiftFormat: 21c9c3c748d5fcece493d8610eee23df15393458
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
-  Teller: 1db21ab2b88a003d4bdb24e2675b835b5819ce85
+  Teller: a632439d546632e9dce1637ea1f225e46bfee921
 
 PODFILE CHECKSUM: d4248ba533b33cea1e19dd96533a503ff96e55e1
 

--- a/Example/Tests/testing/repository/RepositoryMockTest.swift
+++ b/Example/Tests/testing/repository/RepositoryMockTest.swift
@@ -148,6 +148,72 @@ class RepositoryMockTest: XCTestCase {
         XCTAssertEqual(actualSecondResult, expectedInvocations[1])
     }
 
+    // MARK: - refreshIfNoCache
+
+    func test_refreshIfNoCache_expectMockOnlyAfterSet() {
+        repository.refreshIfNoCacheClosure = {
+            Single.just(RefreshResult.successful)
+        }
+
+        XCTAssertFalse(repository.mockCalled)
+
+        _ = try! repository.refreshIfNoCache()
+
+        XCTAssertTrue(repository.mockCalled)
+    }
+
+    func test_refreshIfNoCache_expectCalledOnlyAfterSet() {
+        repository.refreshIfNoCacheClosure = {
+            Single.just(RefreshResult.successful)
+        }
+
+        XCTAssertFalse(repository.refreshIfNoCacheCalled)
+
+        _ = try! repository.refreshIfNoCache()
+
+        XCTAssertTrue(repository.refreshIfNoCacheCalled)
+
+        _ = try! repository.refreshIfNoCache()
+
+        XCTAssertTrue(repository.refreshIfNoCacheCalled)
+    }
+
+    func test_refreshIfNoCache_expectCalledCountIncrementAfterSet() {
+        repository.refreshIfNoCacheClosure = {
+            Single.just(RefreshResult.successful)
+        }
+
+        XCTAssertEqual(repository.refreshIfNoCacheCallsCount, 0)
+
+        _ = try! repository.refreshIfNoCache()
+
+        XCTAssertEqual(repository.refreshIfNoCacheCallsCount, 1)
+
+        _ = try! repository.refreshIfNoCache()
+
+        XCTAssertEqual(repository.refreshIfNoCacheCallsCount, 2)
+    }
+
+    func test_refreshIfNoCache_expectReturnsFromClosure() {
+        var givenInvocations: [RefreshResult] = [
+            RefreshResult.successful,
+            RefreshResult.skipped(reason: .cancelled)
+        ]
+        let expectedInvocations = givenInvocations
+
+        repository.refreshIfNoCacheClosure = {
+            Single.just(givenInvocations.removeFirst())
+        }
+
+        let actualFirstResult = try! repository.refreshIfNoCache().toBlocking().first()!
+
+        XCTAssertEqual(actualFirstResult, expectedInvocations[0])
+
+        let actualSecondResult = try! repository.refreshIfNoCache().toBlocking().first()!
+
+        XCTAssertEqual(actualSecondResult, expectedInvocations[1])
+    }
+
     // MARK: - observe
 
     func test_observe_expectMockOnlyAfterSet() {

--- a/Teller/Classes/testing/repository/RepositoryMock.swift
+++ b/Teller/Classes/testing/repository/RepositoryMock.swift
@@ -43,6 +43,19 @@ public class RepositoryMock<DataSource: RepositoryDataSource>: Repository<DataSo
         return refreshClosure!(force)
     }
 
+    public var refreshIfNoCacheCallsCount = 0
+    public var refreshIfNoCacheCalled: Bool {
+        return refreshIfNoCacheCallsCount > 0
+    }
+
+    public var refreshIfNoCacheClosure: (() -> Single<RefreshResult>)?
+
+    public override func refreshIfNoCache() throws -> Single<RefreshResult> {
+        mockCalled = true
+        refreshIfNoCacheCallsCount += 1
+        return refreshIfNoCacheClosure!()
+    }
+
     public var observeCallsCount = 0
     public var observeCalled: Bool {
         return observeCallsCount > 0


### PR DESCRIPTION
Forgot to do this from last release