### PR TITLE
refactor: repository mock throws like real one

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -17,7 +17,7 @@ PODS:
     - RxSwift (~> 5)
   - SwiftFormat/CLI (0.40.14)
   - SwiftLint (0.37.0)
-  - Teller (0.7.0):
+  - Teller (0.7.1):
     - RxSwift (~> 5.0)
 
 DEPENDENCIES:
@@ -55,7 +55,7 @@ SPEC CHECKSUMS:
   RxTest: 4349afe98f564e0a9bc19063368904622d17d49a
   SwiftFormat: 21c9c3c748d5fcece493d8610eee23df15393458
   SwiftLint: c078a14d7d7ade75e5507795d185e3da41d844d2
-  Teller: a632439d546632e9dce1637ea1f225e46bfee921
+  Teller: 7694cbcadca2db5dda44a2f5dcd2804576f449f2
 
 PODFILE CHECKSUM: d4248ba533b33cea1e19dd96533a503ff96e55e1
 

--- a/Example/Tests/testing/repository/RepositoryMockTest.swift
+++ b/Example/Tests/testing/repository/RepositoryMockTest.swift
@@ -5,6 +5,7 @@ import XCTest
 
 class RepositoryMockTest: XCTestCase {
     var repository: RepositoryMock<ReposRepositoryDataSource>!
+    let defaultRequirements = ReposRepositoryDataSource.Requirements(username: "")
 
     override func setUp() {
         repository = RepositoryMock(dataSource: ReposRepositoryDataSource())
@@ -68,12 +69,14 @@ class RepositoryMockTest: XCTestCase {
 
         XCTAssertFalse(repository.mockCalled)
 
+        repository.requirements = defaultRequirements
         _ = try! repository.refresh(force: false)
 
         XCTAssertTrue(repository.mockCalled)
     }
 
     func test_refresh_expectCalledOnlyAfterSet() {
+        repository.requirements = defaultRequirements
         repository.refreshClosure = { _ in
             Single.just(RefreshResult.successful)
         }
@@ -90,6 +93,7 @@ class RepositoryMockTest: XCTestCase {
     }
 
     func test_refresh_expectCalledCountIncrementAfterSet() {
+        repository.requirements = defaultRequirements
         repository.refreshClosure = { _ in
             Single.just(RefreshResult.successful)
         }
@@ -106,6 +110,7 @@ class RepositoryMockTest: XCTestCase {
     }
 
     func test_refresh_expectInvocationsAppendsAfterSet() {
+        repository.requirements = defaultRequirements
         var givenInvocations: [Bool] = [
             false,
             true
@@ -129,6 +134,7 @@ class RepositoryMockTest: XCTestCase {
     }
 
     func test_refresh_expectReturnsFromClosure() {
+        repository.requirements = defaultRequirements
         var givenInvocations: [RefreshResult] = [
             RefreshResult.successful,
             RefreshResult.skipped(reason: .cancelled)
@@ -148,6 +154,10 @@ class RepositoryMockTest: XCTestCase {
         XCTAssertEqual(actualSecondResult, expectedInvocations[1])
     }
 
+    func test_refresh_givenNoRequirements_expectThrows() {
+        XCTAssertThrowsError(_ = try repository.refreshIfNoCache().toBlocking().first())
+    }
+
     // MARK: - refreshIfNoCache
 
     func test_refreshIfNoCache_expectMockOnlyAfterSet() {
@@ -157,12 +167,14 @@ class RepositoryMockTest: XCTestCase {
 
         XCTAssertFalse(repository.mockCalled)
 
+        repository.requirements = defaultRequirements
         _ = try! repository.refreshIfNoCache()
 
         XCTAssertTrue(repository.mockCalled)
     }
 
     func test_refreshIfNoCache_expectCalledOnlyAfterSet() {
+        repository.requirements = defaultRequirements
         repository.refreshIfNoCacheClosure = {
             Single.just(RefreshResult.successful)
         }
@@ -179,6 +191,7 @@ class RepositoryMockTest: XCTestCase {
     }
 
     func test_refreshIfNoCache_expectCalledCountIncrementAfterSet() {
+        repository.requirements = defaultRequirements
         repository.refreshIfNoCacheClosure = {
             Single.just(RefreshResult.successful)
         }
@@ -195,6 +208,7 @@ class RepositoryMockTest: XCTestCase {
     }
 
     func test_refreshIfNoCache_expectReturnsFromClosure() {
+        repository.requirements = defaultRequirements
         var givenInvocations: [RefreshResult] = [
             RefreshResult.successful,
             RefreshResult.skipped(reason: .cancelled)
@@ -212,6 +226,10 @@ class RepositoryMockTest: XCTestCase {
         let actualSecondResult = try! repository.refreshIfNoCache().toBlocking().first()!
 
         XCTAssertEqual(actualSecondResult, expectedInvocations[1])
+    }
+
+    func test_refreshIfNoCache_givenNoRequirements_expectThrows() {
+        XCTAssertThrowsError(_ = try repository.refreshIfNoCache().toBlocking().first())
     }
 
     // MARK: - observe

--- a/Teller/Classes/testing/repository/RepositoryMock.swift
+++ b/Teller/Classes/testing/repository/RepositoryMock.swift
@@ -37,6 +37,8 @@ public class RepositoryMock<DataSource: RepositoryDataSource>: Repository<DataSo
     public var refreshClosure: ((Bool) -> Single<RefreshResult>)?
 
     public override func refresh(force: Bool) throws -> Single<RefreshResult> {
+        _ = try refreshAssert()
+
         mockCalled = true
         refreshCallsCount += 1
         refreshInvocations.append(force)
@@ -51,6 +53,8 @@ public class RepositoryMock<DataSource: RepositoryDataSource>: Repository<DataSo
     public var refreshIfNoCacheClosure: (() -> Single<RefreshResult>)?
 
     public override func refreshIfNoCache() throws -> Single<RefreshResult> {
+        _ = try refreshAssert()
+
         mockCalled = true
         refreshIfNoCacheCallsCount += 1
         return refreshIfNoCacheClosure!()


### PR DESCRIPTION
To make the mock more realistic, it will throw like the real repository